### PR TITLE
fix: increase timeout used for OldProtocol

### DIFF
--- a/PyP100/auth_protocol.py
+++ b/PyP100/auth_protocol.py
@@ -162,7 +162,7 @@ class OldProtocol:
         log.debug(f"Request raw: {payload}")
 
         # Execute call
-        resp = self.session.post(url, json=payload, timeout=0.5)
+        resp = self.session.post(url, json=payload, timeout=2)
         resp.raise_for_status()
         data = resp.json()
 


### PR DESCRIPTION
As well as allowing devices with marginal coverage more time to respond this brings the timeout in line with that used by the newer auth protocol

Helps with https://github.com/almottier/TapoP100/issues/14 