### PR TITLE
Add support for `get_energy_data`

### DIFF
--- a/PyP100/PyP100.py
+++ b/PyP100/PyP100.py
@@ -1,5 +1,8 @@
 import logging
 from base64 import b64decode
+
+from PyP100 import MeasureInterval
+
 from .auth_protocol import AuthProtocol, OldProtocol
 
 log = logging.getLogger(__name__)
@@ -33,7 +36,8 @@ class Device:
                     self.protocol = protocol
                 except:
                     log.exception(
-                        f"Failed to initialize protocol {protocol_class.__name__}"
+                        f"Failed to initialize protocol {
+                            protocol_class.__name__}"
                     )
         if not self.protocol:
             raise Exception("Failed to initialize protocol")
@@ -104,6 +108,10 @@ class Switchable(Device):
 class Metering(Device):
     def getEnergyUsage(self) -> dict:
         return self.request("get_energy_usage")
+
+    def getEnergyData(self, start_timestamp: int, end_timestamp: int, interval: MeasureInterval) -> dict:
+        """Hours are always ignored, start is rounded to midnight, first day of month or first of January based on interval"""
+        return self.request("get_energy_data", {"start_timestamp": start_timestamp, "end_timestamp": end_timestamp, "interval": interval.value})
 
 
 class Color(Device):

--- a/PyP100/__init__.py
+++ b/PyP100/__init__.py
@@ -1,1 +1,7 @@
+from enum import IntEnum
 
+
+class MeasureInterval(IntEnum):
+    HOURS = 60
+    DAYS = 1440
+    MONTHS = 43200

--- a/README.md
+++ b/README.md
@@ -70,7 +70,10 @@ p110 = PyP110.P110("192.168.X.X", "email@gmail.com", "Password123")
 
 # The P110 has all the same basic functions as the plugs and additionally allow for energy monitoring.
 p110.getEnergyUsage()  # Returns dict with all of the energy usage of the connected plug
+p110.getEnergyData(1706825847, 1708643847, MeasureInterval.DAYS) # Returns power consumption per day since 1st Feb 24
 ```
+
+If you call `getEnergyData` function, power consumption could be collected per `HOURS`, `DAYS` or `MONTHS` interval. The start timestamp is ([most probably](https://github.com/fishbigger/TapoP100/pull/87#issuecomment-1565334341)) rounded to the midnight, the first day of month or the first of January based on interval.
 
 ## Contributing
 


### PR DESCRIPTION
This pull request adds support for `get_energy_data` calls. It allow you to query for a historical data about power consumption. You could specify time window and interval. I tested my PR on Tapo P110 with firmware 1.3.0:

```python
>>> from PyP100 import PyP110
>>> dev = PyP110.P110("10.0.0.1", "abc", "cdf")
>>> dev.getEnergyData(1706825847, 1708643847, MeasureInterval.DAYS) # Show power consumption per day sice 1st Feb 24
{'local_time': '2024-02-23 00:18:54', 'data': [806, 820, 925, 892, 852, 854, 839, 836, 842, 831, 841, 821, 809, 822, 800, 805, 793, 794, 0, 0, 0, 344, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], 'start_timestamp': 1706825847, 'end_timestamp': 1708643847, 'interval': 1440}
```

This PR was based on code and comments from https://github.com/fishbigger/TapoP100/pull/87, it will probably resolve #17 