### PR TITLE
Fix for "SyntaxError: EOL while scanning string literal"

### DIFF
--- a/PyP100/PyP100.py
+++ b/PyP100/PyP100.py
@@ -36,8 +36,7 @@ class Device:
                     self.protocol = protocol
                 except:
                     log.exception(
-                        f"Failed to initialize protocol {
-                            protocol_class.__name__}"
+                        f"Failed to initialize protocol {protocol_class.__name__}"
                     )
         if not self.protocol:
             raise Exception("Failed to initialize protocol")


### PR DESCRIPTION
I couldn't use the library until I removed this new line character, I was getting this error:

```
> Traceback (most recent call last):
>   File "xxx", line 1, in <module>
>     from PyP100 import PyP110
>   File "/home/xxx/.local/lib/python3.9/site-packages/PyP100/PyP110.py", line 1, in <mod                                                                                                                        ule>
>     from PyP100.PyP100 import Switchable, Metering
>   File "/home/xxx/.local/lib/python3.9/site-packages/PyP100/PyP100.py", line 39
>     f"Failed to initialize protocol {
>                                      ^
> SyntaxError: EOL while scanning string literal
> 
```