### PR TITLE
add terminalUUID to payload for P105 error -1012 (#21)

### DIFF
--- a/PyP100/PyP100.py
+++ b/PyP100/PyP100.py
@@ -86,7 +86,8 @@ class Switchable(Device):
         return self._get_device_info()["device_on"]
 
     def set_status(self, status: bool):
-        return self._set_device_info({"device_on": status})
+        mac = self._get_device_info()["mac"]
+        return self._set_device_info({"device_on": status, "terminalUUID": mac})
 
     def turnOn(self):
         return self.set_status(True)

--- a/PyP100/auth_protocol.py
+++ b/PyP100/auth_protocol.py
@@ -51,6 +51,10 @@ class AuthProtocol:
             self.Initialize()
         payload = {"method": method}
         if params:
+            # P105 requires terminalUUID in payload
+            if "terminalUUID" in params.keys():
+                payload["terminalUUID"] = params["terminalUUID"]
+                del params["terminalUUID"]
             payload["params"] = params
         log.debug(f"Request: {payload}")
         # Encrypt payload and execute call


### PR DESCRIPTION
resolve https://github.com/almottier/TapoP100/issues/21

P105 `turnOn()` or `turnOff()` fail with error `-1012`.

To resolve this, `terminallUUID` must be set in payload.
