### PR TITLE
Drop pkcs7 from install requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,6 @@ setup_args = dict(
 
 install_requires = [
     "pycryptodome>=3.9.8",
-    "pkcs7>=0.1.2",
     "requests>=2.24.0",
 ]
 


### PR DESCRIPTION
`pkcs7` doesn't seem to be used anywhere anymore.
Basic testing works without it being installed.

Btw, thanks for creating this fork! It saved me after one of my smart plugs inadvertently auto-updated.